### PR TITLE
Added entity details page, with ability to edit/create

### DIFF
--- a/mhvdb2/resources/entities.py
+++ b/mhvdb2/resources/entities.py
@@ -1,0 +1,39 @@
+from mhvdb2.models import Entity
+from peewee import DoesNotExist
+import re
+
+
+def get(entity_id):
+    try:
+        return Entity.get(Entity.id == entity_id)
+    except DoesNotExist:
+        return None
+
+
+def validate(name, email, phone):
+    errors = []
+    if not name:
+        errors.append("Sorry, you need to provide a name.")
+    if email and not re.match("[^@\s]+@[^@\s]+", email):
+        errors.append("Sorry, that isn't a valid email address.")
+
+    return errors
+
+
+def create(name, email, phone):
+    entity = Entity()
+    entity.is_member = False
+    entity.name = name
+    entity.email = email
+    entity.phone = phone
+    entity.save()
+    return entity.id
+
+
+# Update entity
+def update(entity_id, name, email, phone):
+    entity = Entity.get(Entity.id == entity_id)
+    entity.name = name
+    entity.email = email
+    entity.phone = phone
+    entity.save()

--- a/mhvdb2/templates/admin/entities.html
+++ b/mhvdb2/templates/admin/entities.html
@@ -2,9 +2,15 @@
 {% set active_page = "admin_entities" %}
 
 {% block title %}Admin - Members{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/jasny-bootstrap/3.1.3/css/jasny-bootstrap.min.css">
+{% endblock %}
 {% block content %}
 <h1>Admin - Entities</h1>
-<p>Here's a table of all entities that aren't members:</p>
+<p class="pull-left">Here's a table of all entities that aren't members:</p>
+<a class="btn btn-primary pull-right" href="{{url_for('entity_new_get')}}">
+    <i class="fa fa-plus"></i> New Entity
+</a>
 <table class="table table-hover">
     <thead>
         <tr>
@@ -13,10 +19,10 @@
             <th>Phone Number</th>
         </tr>
     </thead>
-    <tbody>
+    <tbody data-link="row" class="rowlink">
         {% for entity in entities %}
         <tr>
-            <td>{{ entity.name }}</td>
+            <td><a href="{{url_for('entity_get', entity_id=entity.id)}}">{{ entity.name }}</a></td>
             <td>{{ entity.email }}</td>
             <td>{{ entity.phone }}</td>
         </tr>
@@ -24,4 +30,7 @@
     </tbody>
 
 </table>
+{% endblock %}
+{% block scripts %}
+<script src="//cdnjs.cloudflare.com/ajax/libs/jasny-bootstrap/3.1.3/js/jasny-bootstrap.min.js"></script>
 {% endblock %}

--- a/mhvdb2/templates/admin/entity.html
+++ b/mhvdb2/templates/admin/entity.html
@@ -1,0 +1,23 @@
+{% extends "_layout.html" %}
+{% set active_page = "entity" %}
+
+{% block title %}{% if new %}New Entity{% else %}{{name}}{% endif %}{% endblock %}
+{% block content %}
+<h1>{% if new %}New Entity{% else %}{{name}}{% endif %}</h1>
+<form method="POST" role="form" class="col-sm-8 col-md-6 col-lg-5">
+    <div class="form-group">
+        <label for="name">Name</label>
+        <input required type="text" class="form-control" name="name" id="name" value="{{name}}">
+    </div>
+    <div class="form-group">
+        <label for="email">Email Address</label>
+        <input type="email" class="form-control" name="email" id="email" value="{{email}}">
+    </div>
+    <div class="form-group">
+        <label for="phone">Phone Number</label>
+        <input type="text" class="form-control" name="phone" id="phone" value="{{phone}}">
+    </div>
+    <button type="submit" class="btn btn-primary">{% if new %}Create{% else %}Update{% endif %}</button>
+    <a class="btn btn-secondary text-danger" href="{{url_for('admin_entities')}}">Cancel</a>
+</form>
+{% endblock %}

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,101 @@
+from mhvdb2 import app
+import unittest
+
+
+class test_entity(unittest.TestCase):
+    def setUp(self):
+        self.app = app.test_client()
+
+    def test_entity_new_get(self):
+        rv = self.app.get('/admin/entities/new', follow_redirects=True)
+        self.assertEqual(rv.status_code, 200,
+                         "Incorrect status code when retrieving page")
+
+    def test_entity_new_post(self):
+        endpoint = '/admin/entities/new'
+        valid = {
+            "name": "Testing entity",
+            "email": "test@example.com",
+            "phone": "01189998219991197253"
+        }
+
+        rv = self.app.post(endpoint, follow_redirects=True, data=valid)
+        self.assertEqual(rv.status_code, 200,
+                         "Incorrect status code when valid data is submitted")
+
+        # No phone number
+        data = valid.copy()
+        data["phone"] = None
+        rv = self.app.post(endpoint, follow_redirects=True, data=data)
+        self.assertEqual(rv.status_code, 200,
+                         "Incorrect status code when valid data is submitted without phone")
+
+        # No email address
+        data = valid.copy()
+        data["email"] = None
+        rv = self.app.post(endpoint, follow_redirects=True, data=data)
+        self.assertEqual(rv.status_code, 200,
+                         "Incorrect status code when valid data is submitted without email")
+
+        # Missing name
+        data = valid.copy()
+        data["name"] = None
+        rv = self.app.post(endpoint, follow_redirects=True, data=data)
+        self.assertEqual(rv.status_code, 400,
+                         "Incorrect status code when name is missing")
+
+        # Invalid email
+        data = valid.copy()
+        data["email"] = "google.com"
+        rv = self.app.post(endpoint, follow_redirects=True, data=data)
+        self.assertEqual(rv.status_code, 400,
+                         "Incorrect status code when email is malformed")
+
+    def test_entity_get(self):
+        rv = self.app.get('/admin/entities/1', follow_redirects=True)
+        self.assertEqual(rv.status_code, 200,
+                         "Incorrect status code when retrieving page")
+
+    def test_entity_post(self):
+        endpoint = '/admin/entities/1'
+        valid = {
+            "name": "Testing entity update",
+            "email": "updated@example.com",
+            "phone": "12345"
+        }
+
+        rv = self.app.post(endpoint, follow_redirects=True, data=valid)
+        self.assertEqual(rv.status_code, 200,
+                         "Incorrect status code when valid data is submitted")
+
+        # No phone number
+        data = valid.copy()
+        data["phone"] = None
+        rv = self.app.post(endpoint, follow_redirects=True, data=data)
+        self.assertEqual(rv.status_code, 200,
+                         "Incorrect status code when valid data is submitted without phone")
+
+        # No email address
+        data = valid.copy()
+        data["email"] = None
+        rv = self.app.post(endpoint, follow_redirects=True, data=data)
+        self.assertEqual(rv.status_code, 200,
+                         "Incorrect status code when valid data is submitted without email")
+
+        # Missing name
+        data = valid.copy()
+        data["name"] = None
+        rv = self.app.post(endpoint, follow_redirects=True, data=data)
+        self.assertEqual(rv.status_code, 400,
+                         "Incorrect status code when name is missing")
+
+        # Invalid email
+        data = valid.copy()
+        data["email"] = "google.com"
+        rv = self.app.post(endpoint, follow_redirects=True, data=data)
+        self.assertEqual(rv.status_code, 400,
+                         "Incorrect status code when email is malformed")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This fixes #13 and #31.
Changes:
- Added button to `/admin/entities` to create new entity
- Made each row a link to view more details / edit the entity
- Added page to create/edit an entity
- Added tests for new page
