### PR TITLE
Added support for datatables (fixes #14)

### DIFF
--- a/mhvdb2/static/style.css
+++ b/mhvdb2/static/style.css
@@ -13,3 +13,7 @@ input.copy {
 	color: #333 !important;
 	width: auto;
 }
+
+.dataTables_filter  input {
+	margin-left: 1ex;
+}

--- a/mhvdb2/templates/_datatables.html
+++ b/mhvdb2/templates/_datatables.html
@@ -1,0 +1,13 @@
+{% extends "_layout.html" %}
+{% block template_head %}
+<link rel="stylesheet" href="//cdn.datatables.net/plug-ins/be7019ee387/integration/bootstrap/3/dataTables.bootstrap.css">
+{% endblock %}
+{% block template_scripts %}
+<script src="//cdn.datatables.net/1.10.0/js/jquery.dataTables.js"></script>
+<script src="//cdn.datatables.net/plug-ins/be7019ee387/integration/bootstrap/3/dataTables.bootstrap.js"></script>
+<script type="text/javascript">
+    $(document).ready(function() {
+        $('.datatable').dataTable();
+    } );
+</script>
+{% endblock %}

--- a/mhvdb2/templates/_layout.html
+++ b/mhvdb2/templates/_layout.html
@@ -27,6 +27,7 @@
         <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
         <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
         <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+        {% block template_head %}{% endblock %}
         {% block head %}{% endblock %}
     </head>
     <body>
@@ -65,6 +66,7 @@
 
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
         <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+        {% block template_scripts %}{% endblock %}
         {% block scripts %}{% endblock %}
     </body>
 </html>

--- a/mhvdb2/templates/admin/entities.html
+++ b/mhvdb2/templates/admin/entities.html
@@ -1,5 +1,6 @@
-{% extends "_layout.html" %}
+{% extends "_datatables.html" %}
 {% set active_page = "admin_entities" %}
+{% set datatables = True %}
 
 {% block title %}Admin - Members{% endblock %}
 {% block head %}
@@ -11,7 +12,8 @@
 <a class="btn btn-primary pull-right" href="{{url_for('entity_new_get')}}">
     <i class="fa fa-plus"></i> New Entity
 </a>
-<table class="table table-hover">
+<div class="clearfix" style="margin-bottom: 20px"></div>
+<table class="table table-hover datatable">
     <thead>
         <tr>
             <th>Name</th>

--- a/mhvdb2/templates/admin/members.html
+++ b/mhvdb2/templates/admin/members.html
@@ -1,11 +1,11 @@
-{% extends "_layout.html" %}
+{% extends "_datatables.html" %}
 {% set active_page = "admin_members" %}
 
 {% block title %}Admin - Members{% endblock %}
 {% block content %}
 <h1>Admin - Members</h1>
 <p>Here's a table of all members:</p>
-<table class="table table-hover">
+<table class="table table-hover datatable">
     <thead>
         <tr>
             <th>Name</th>

--- a/mhvdb2/templates/admin/transactions.html
+++ b/mhvdb2/templates/admin/transactions.html
@@ -1,11 +1,11 @@
-{% extends "_layout.html" %}
+{% extends "_datatables.html" %}
 {% set active_page = "admin_members" %}
 
 {% block title %}Admin - Transactions{% endblock %}
 {% block content %}
 <h1>Admin - Transactions</h1>
 <p>Here's a table of all transactions:</p>
-<table class="table table-hover">
+<table class="table table-hover datatable">
     <thead>
         <tr>
             <th>Time</th>


### PR DESCRIPTION
Changes:
- Add some more blocks to the base layout for template extensions.
- Add a new template with the `datatables` CSS and JS files imported
- Convert pages that currently implement large tables to use the new datatables template
